### PR TITLE
Validate PDF uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv/
+__pycache__/
+*.pyc
+instance/

--- a/app.py
+++ b/app.py
@@ -192,10 +192,13 @@ def upload_job():
     if not job_file:
         flash('Please select a job description file.', 'danger')
         return redirect(url_for('employer_dashboard'))
+    filename = secure_filename(job_file.filename)
+    if not filename.lower().endswith('.pdf'):
+        flash('Only PDF files are allowed.', 'danger')
+        return redirect(url_for('employer_dashboard'))
     # Ensure uploads folder exists
     if not os.path.exists(app.config['UPLOAD_FOLDER']):
         os.makedirs(app.config['UPLOAD_FOLDER'])
-    filename = secure_filename(job_file.filename)
     file_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
     job_file.save(file_path)
     # Record this job upload in jobs.json with employer association
@@ -232,6 +235,9 @@ def upload_resume():
     # Handle job description input (either an existing selection or a new upload)
     if uploaded_jd:
         jd_filename = secure_filename(uploaded_jd.filename)
+        if not jd_filename.lower().endswith('.pdf'):
+            flash('Only PDF files are allowed.', 'danger')
+            return redirect(url_for('user_dashboard'))
         job_desc_path = os.path.join(app.config['UPLOAD_FOLDER'], jd_filename)
         uploaded_jd.save(job_desc_path)
     elif selected_jd:
@@ -244,6 +250,9 @@ def upload_resume():
         return redirect(url_for('user_dashboard'))
     # Save the uploaded resume file
     resume_filename = secure_filename(resume_file.filename)
+    if not resume_filename.lower().endswith('.pdf'):
+        flash('Only PDF files are allowed.', 'danger')
+        return redirect(url_for('user_dashboard'))
     resume_path = os.path.join(app.config['UPLOAD_FOLDER'], resume_filename)
     resume_file.save(resume_path)
     # Extract text from resume and job description PDFs

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -1,0 +1,81 @@
+import io
+import os
+import pytest
+from flask_sqlalchemy import query as fsq
+
+import app
+
+class DummyPage:
+    def extract_text(self):
+        return "text"
+
+class DummyPDF:
+    def __init__(self, f):
+        pass
+    @property
+    def pages(self):
+        return [DummyPage()]
+
+@pytest.fixture(autouse=True)
+def patch_pdf(monkeypatch):
+    monkeypatch.setattr(app, "PdfReader", DummyPDF)
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    app.app.config["TESTING"] = True
+    app.app.config["UPLOAD_FOLDER"] = tmp_path
+    monkeypatch.setattr(app, "MATCHES_FILE", str(tmp_path / "matches.json"))
+    monkeypatch.setattr(app, "JOBS_FILE", str(tmp_path / "jobs.json"))
+    with app.app.test_client() as client:
+        yield client
+
+def login(client, role="user"):
+    with client.session_transaction() as sess:
+        sess["user_id"] = 1
+        sess["role"] = role
+
+class DummyUser:
+    full_name = "User"
+    email = "user@example.com"
+
+@pytest.fixture(autouse=True)
+def patch_user(monkeypatch):
+    monkeypatch.setattr(fsq.Query, "get", lambda self, ident: DummyUser())
+
+
+def test_upload_job_pdf(client):
+    login(client, role="employer")
+    data = {"job_description": (io.BytesIO(b"%PDF-1.4\n"), "job.pdf")}
+    resp = client.post("/upload-job", data=data, content_type="multipart/form-data", follow_redirects=True)
+    assert b"uploaded successfully" in resp.data.lower()
+    assert os.path.exists(os.path.join(app.app.config["UPLOAD_FOLDER"], "job.pdf"))
+
+
+def test_upload_job_non_pdf(client):
+    login(client, role="employer")
+    data = {"job_description": (io.BytesIO(b"data"), "job.txt")}
+    resp = client.post("/upload-job", data=data, content_type="multipart/form-data", follow_redirects=True)
+    assert b"only pdf files are allowed" in resp.data.lower()
+
+
+def test_upload_resume_pdf(client):
+    login(client, role="user")
+    data = {
+        "resume": (io.BytesIO(b"%PDF-1.4\n"), "resume.pdf"),
+        "job_description": (io.BytesIO(b"%PDF-1.4\n"), "desc.pdf"),
+    }
+    resp = client.post("/upload-resume", data=data, content_type="multipart/form-data", follow_redirects=True)
+    assert b"resume matched" in resp.data.lower()
+
+
+def test_upload_resume_non_pdf(client):
+    login(client, role="user")
+    data = {
+        "resume": (io.BytesIO(b"data"), "resume.txt"),
+        "job_description": (io.BytesIO(b"%PDF-1.4\n"), "desc.pdf"),
+    }
+    resp = client.post("/upload-resume", data=data, content_type="multipart/form-data", follow_redirects=True)
+    with client.session_transaction() as sess:
+        flashes = sess.get("_flashes", [])
+    assert (b"only pdf files are allowed" in resp.data.lower()) or any("Only PDF files are allowed" in msg for _cat, msg in flashes)
+


### PR DESCRIPTION
## Summary
- require PDF extensions for uploaded job descriptions and resumes
- ignore virtualenv and caches
- add unit tests for allowed and rejected file types

## Testing
- `PYTHONPATH=venv/lib/python3.12/site-packages:. pytest -q`
