### PR TITLE
Ensure unique filenames on upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv/
+uploads/
+__pycache__/
+.DS_Store


### PR DESCRIPTION
## Summary
- ignore virtual environment and uploads
- generate UUID-based unique filenames for uploaded resumes and job descriptions

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687ee0f430d8832aac70246d70690fb4