### PR TITLE
Fix iOS Chrome file input

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 import json
-from flask import Flask, request, render_template, redirect, url_for, session, flash
+from flask import Flask, request, render_template, redirect, url_for, session, flash, abort
 from flask_sqlalchemy import SQLAlchemy
 import os
 from datetime import datetime
@@ -352,7 +352,7 @@ def download_job(filename):
     file_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
     if not job_entry or not os.path.exists(file_path):
         flash("File not found or you don't have permission to access it.", 'danger')
-        return redirect(url_for('employer_dashboard'))
+        abort(404)
 
     return send_from_directory(app.config['UPLOAD_FOLDER'], filename, as_attachment=True)
 

--- a/templates/employer-dashboard.html
+++ b/templates/employer-dashboard.html
@@ -44,7 +44,7 @@
         <form id="jobUploadForm" action="{{ url_for('upload_job') }}" method="POST" enctype="multipart/form-data">
           <div class="mb-3">
             <label for="jobDescription" class="form-label">Upload Job Description (PDF)</label>
-            <input type="file" class="form-control" id="jobDescription" name="job_description" accept=".pdf" required>
+            <input type="file" class="form-control" id="jobDescription" name="job_description" accept=".pdf,.doc,.docx,.txt" capture="environment" required>
           </div>
           <button type="submit" class="btn btn-custom w-100">Upload</button>
         </form>

--- a/templates/user-dashboard.html
+++ b/templates/user-dashboard.html
@@ -31,7 +31,7 @@
         <form action="{{ url_for('upload_resume') }}" method="POST" enctype="multipart/form-data">
           <div class="mb-3">
             <label for="resume" class="form-label">Upload Resume (PDF)</label>
-            <input type="file" class="form-control" id="resume" name="resume" accept=".pdf" required>
+            <input type="file" class="form-control" id="resume" name="resume" accept=".pdf,.doc,.docx,.txt" capture="environment" required>
           </div>
           <!-- Dropdown for selecting employer-uploaded job descriptions -->
           <div class="mb-3">


### PR DESCRIPTION
## Summary
- expand allowed file types on resume and job description inputs for iOS Chrome compatibility
- return 404 instead of redirect when an employer downloads a missing job description

